### PR TITLE
Remove redundant resolving of completion item

### DIFF
--- a/vividus-studio-server/vividus-studio-plugin/src/main/java/org/vividus/studio/plugin/service/CompletionItemService.java
+++ b/vividus-studio-server/vividus-studio-plugin/src/main/java/org/vividus/studio/plugin/service/CompletionItemService.java
@@ -105,15 +105,6 @@ public class CompletionItemService implements ICompletionItemService
     }
 
     @Override
-    public CompletionItem findOne(CompletionItem unresolved)
-    {
-        JsonObject data = (JsonObject) unresolved.getData();
-        String key = data.get(TRIGGER).getAsString();
-        int hash = data.get(HASH).getAsInt();
-        return completionItem.get().get(key).get(hash);
-    }
-
-    @Override
     public List<CompletionItem> findAll(String trigger)
     {
         return completionItem.get().get(trigger).values().stream().collect(Collectors.toList());

--- a/vividus-studio-server/vividus-studio-plugin/src/main/java/org/vividus/studio/plugin/service/ICompletionItemService.java
+++ b/vividus-studio-server/vividus-studio-plugin/src/main/java/org/vividus/studio/plugin/service/ICompletionItemService.java
@@ -25,7 +25,5 @@ import org.eclipse.lsp4j.CompletionItem;
 
 public interface ICompletionItemService extends IStepDefinitionsAware
 {
-    CompletionItem findOne(CompletionItem unresolved);
-
     List<CompletionItem> findAll(String trigger);
 }

--- a/vividus-studio-server/vividus-studio-plugin/src/main/java/org/vividus/studio/plugin/service/VividusStudioTextDocumentService.java
+++ b/vividus-studio-server/vividus-studio-plugin/src/main/java/org/vividus/studio/plugin/service/VividusStudioTextDocumentService.java
@@ -71,7 +71,7 @@ public class VividusStudioTextDocumentService implements TextDocumentService
     @Override
     public CompletableFuture<CompletionItem> resolveCompletionItem(CompletionItem unresolved)
     {
-        return CompletableFuture.supplyAsync(() -> completionItemService.findOne(unresolved));
+        return CompletableFuture.completedFuture(unresolved);
     }
 
     @Override

--- a/vividus-studio-server/vividus-studio-plugin/src/test/java/org/vividus/studio/plugin/service/CompletionItemServiceTests.java
+++ b/vividus-studio-server/vividus-studio-plugin/src/test/java/org/vividus/studio/plugin/service/CompletionItemServiceTests.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -67,8 +66,6 @@ class CompletionItemServiceTests
     private static final String MODULE = "module";
     private static final String HASH = "hash";
     private static final String TRIGGER = "trigger";
-    private static final String SEP = ",";
-    private static final String EMPTY = "";
 
     @InjectMocks private CompletionItemService completionItemService;
 
@@ -114,28 +111,6 @@ class CompletionItemServiceTests
             () -> assertEquals(trigger, data.get(TRIGGER).getAsString()),
             () -> assertEquals(hash, data.get(HASH).getAsInt()),
             () -> assertEquals(tags, item.getTags())
-        );
-    }
-
-    @CsvSource({
-        GIVEN_TRIGGER + SEP + GIVEN_STEP + SEP + GIVEN_STEP_SNIPPET + SEP + GIVEN_STEP_HASH,
-        WHEN_TRIGGER + SEP + WHEN_STEP + SEP + WHEN_STEP_SNIPPET + SEP + WHEN_STEP_HASH,
-        THEN_TRIGGER + SEP + THEN_STEP + SEP + THEN_STEP_SNIPPET + SEP + THEN_STEP_HASH
-    })
-    @ParameterizedTest
-    void testFindOne(String trigger, String label, String snippet, int hash)
-    {
-        JsonObject data = new JsonObject();
-        data.addProperty(TRIGGER, trigger);
-        data.addProperty(HASH, hash);
-        CompletionItem unresolved = new CompletionItem();
-        unresolved.setData(data);
-        CompletionItem resolved = completionItemService.findOne(unresolved);
-        JsonObject resolvedData = (JsonObject) resolved.getData();
-        assertAll(
-            () -> assertEquals(label, resolved.getLabel()),
-            () -> assertEquals(trigger, resolvedData.get(TRIGGER).getAsString()),
-            () -> assertEquals(hash, resolvedData.get(HASH).getAsInt())
         );
     }
 }

--- a/vividus-studio-server/vividus-studio-plugin/src/test/java/org/vividus/studio/plugin/service/VividusStudioTextDocumentServiceTests.java
+++ b/vividus-studio-server/vividus-studio-plugin/src/test/java/org/vividus/studio/plugin/service/VividusStudioTextDocumentServiceTests.java
@@ -73,12 +73,10 @@ class VividusStudioTextDocumentServiceTests
     @Test
     void testResolveCompletionItem() throws InterruptedException, ExecutionException
     {
-        CompletionItem unresolvedItem = mock(CompletionItem.class);
-        CompletionItem resolvedItem = mock(CompletionItem.class);
-        when(completionItemService.findOne(unresolvedItem)).thenReturn(resolvedItem);
-        CompletionItem outputItem = textDocumentService.resolveCompletionItem(unresolvedItem).get();
-        assertEquals(resolvedItem, outputItem);
-        verifyNoMoreInteractions(completionItemService, resolvedItem, unresolvedItem);
+        CompletionItem item = mock(CompletionItem.class);
+        CompletionItem outputItem = textDocumentService.resolveCompletionItem(item).get();
+        assertEquals(item, outputItem);
+        verifyNoInteractions(completionItemService, item);
     }
 
     @Test


### PR DESCRIPTION
VS Code gets all the info through the first request for the completion list, so there is no additional information that needs to be resolved.