### PR TITLE
Fix error when non-step completion is invoked in the middle of scenario

### DIFF
--- a/vividus-studio-server/vividus-studio-plugin/src/main/java/org/vividus/studio/plugin/service/CompletionItemService.java
+++ b/vividus-studio-server/vividus-studio-plugin/src/main/java/org/vividus/studio/plugin/service/CompletionItemService.java
@@ -217,7 +217,7 @@ public class CompletionItemService implements ICompletionItemService
             return Optional.of(entry(type.get(), token));
         }
 
-        return findStepHeadIndex(document).map(e ->
+        return findStepHeadIndex(lineIndex, document).map(e ->
         {
             String multilineToken = document.subList(e.getValue(), lineIndex).stream()
                     .collect(Collectors.joining(System.lineSeparator(), "", token));
@@ -230,13 +230,13 @@ public class CompletionItemService implements ICompletionItemService
         return STEP_BREAKERS.stream().anyMatch(line::startsWith);
     }
 
-    private static Optional<Entry<StepType, Integer>> findStepHeadIndex(List<String> lines)
+    private static Optional<Entry<StepType, Integer>> findStepHeadIndex(int currentIndex, List<String> lines)
     {
         for (int index = lines.size() - 1; index >= 0; index--)
         {
             String line = lines.get(index);
             Optional<StepType> type = StepType.detectSafely(line);
-            if (type.isPresent())
+            if (type.isPresent() && currentIndex > index)
             {
                 return Optional.of(entry(type.get(), index));
             }

--- a/vividus-studio-server/vividus-studio-plugin/src/test/java/org/vividus/studio/plugin/service/CompletionItemServiceTests.java
+++ b/vividus-studio-server/vividus-studio-plugin/src/test/java/org/vividus/studio/plugin/service/CompletionItemServiceTests.java
@@ -125,7 +125,14 @@ class CompletionItemServiceTests
             arguments(List.of("Nutty", "Putty", "Cave"), 2, 3),
             arguments(List.of("When I procrastinate"), 0, 20),
             arguments(List.of("Scenario: Salute to the Sun"), 0, 35),
-            arguments(List.of("Scenario: Salute", "to", "the", "Sun"), 3, 2)
+            arguments(List.of("Scenario: Salute", "to", "the", "Sun"), 3, 2),
+            arguments(List.of(
+                "Scenario: Have no idea how to name it :(",
+                "Given friday",
+                "When I try to work",
+                "O",
+                "Then work is not going"
+                ), 3, 1)
         );
     }
 


### PR DESCRIPTION
```
[Error - 3:43:07 PM] Request textDocument/completion failed.
  Message: Internal error.
  Code: -32603 
java.util.concurrent.CompletionException: java.lang.IllegalArgumentException: fromIndex(6) > toIndex(4)
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:314)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:319)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1773)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1763)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1016)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1665)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1598)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
Caused by: java.lang.IllegalArgumentException: fromIndex(6) > toIndex(4)
	at java.base/java.util.AbstractList.subListRangeCheck(AbstractList.java:509)
	at java.base/java.util.ArrayList.subList(ArrayList.java:1104)
	at org.vividus.studio.plugin.service.CompletionItemService.lambda$6(CompletionItemService.java:231)
	at java.base/java.util.Optional.map(Optional.java:258)
	at org.vividus.studio.plugin.service.CompletionItemService.findStep(CompletionItemService.java:223)
	at org.vividus.studio.plugin.service.CompletionItemService.findAllAtPosition(CompletionItemService.java:153)
	at org.vividus.studio.plugin.service.VividusStudioTextDocumentService.lambda$0(VividusStudioTextDocumentService.java:63)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1771)
	... 6 more
```