### PR TITLE
Fix semantics error occured when user selects vividus language mode for new text file that was not saved on the disc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * (Fixes https://github.com/vividus-framework/vividus-studio/issues/367) Fix meta parsing to not consider  meta sign in step as part of meta tags block
+* Fix semantics error occurred when user selects VIVIDUS language mode for new text file that was not saved on the file system
 
 ## [0.1.4] - 2023-02-21
 

--- a/vividus-studio-server/vividus-studio-plugin/src/main/java/org/vividus/studio/plugin/service/StepDefinitionResolver.java
+++ b/vividus-studio-server/vividus-studio-plugin/src/main/java/org/vividus/studio/plugin/service/StepDefinitionResolver.java
@@ -88,6 +88,11 @@ public class StepDefinitionResolver implements IStepDefinitionsAware
     public Stream<ResolvedStepDefinition> resolve(String documentIdentifier)
     {
         List<String> document = textDocumentProvider.getTextDocument(documentIdentifier);
+        if (document.isEmpty())
+        {
+            return Stream.empty();
+        }
+
         int searchIndex = document.size() - 1;
 
         List<Step> steps = new ArrayList<>(document.size());

--- a/vividus-studio-server/vividus-studio-plugin/src/test/java/org/vividus/studio/plugin/service/StepDefinitionResolverTests.java
+++ b/vividus-studio-server/vividus-studio-plugin/src/test/java/org/vividus/studio/plugin/service/StepDefinitionResolverTests.java
@@ -20,7 +20,9 @@
 package org.vividus.studio.plugin.service;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.when;
@@ -181,6 +183,15 @@ class StepDefinitionResolverTests
         assertStepDefinition(resolvedDefinitions.get(3), 5, 2, List.of(5, 20, 33, 36));
         assertStepDefinition(resolvedDefinitions.get(4), 6, 1, List.of(15, 18));
         assertStepDefinition(resolvedDefinitions.get(5), 7, 1, List.of(5, 8));
+    }
+
+    @Test
+    void shouldNotResolveForEmptyDocument()
+    {
+        when(textDocumentProvider.getTextDocument(DOCUMENT_ID)).thenReturn(List.of());
+
+        List<ResolvedStepDefinition> definitions = resolver.resolve(DOCUMENT_ID).collect(Collectors.toList());
+        assertThat(definitions, is(empty()));
     }
 
     @Test


### PR DESCRIPTION
When we create a new file using File -> New Text File commands the created file is not presented on the filesystem and there are no onOpen or onChange events being sent to the server, so we can't track it, initially when we select vividus language mode only highlight provided by VSCode will work, the semantic tokens highlight provided by the server will work only when the file is saved.