### PR TITLE
[CI] Fix NPM package installation warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,5 +52,5 @@ jobs:
       
       - name: Extension packaging
         run: |
-          sudo npm install -g vsce
+          sudo npm install -g @vscode/vsce
           vsce package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Extension packaging
         run: |
-          sudo npm install -g vsce
+          sudo npm install -g @vscode/vsce
           npm install
           vsce package
 


### PR DESCRIPTION
Fixed warning:

> npm WARN deprecated vsce@2.15.0: vsce has been renamed to @vscode/vsce. Install using @vscode/vsce instead.