### PR TITLE
Improve Syntax Highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Fix highlighting of GivenStories filtered by scenario meta parameters
+* Add highlighting for 'Descrption' story element
 
 ## [0.1.10] - 2024-01-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+* Fix highlighting of GivenStories filtered by scenario meta parameters
+
 ## [0.1.10] - 2024-01-02
 
 * Add auto-completion support for step parameters with limited number of choices

--- a/syntaxes/vividus.story.tmLanguage.json
+++ b/syntaxes/vividus.story.tmLanguage.json
@@ -182,7 +182,7 @@
             }
         },
         "givenStoriesPath": {
-            "match": "(\\s*\\/?[^\\s]*\\.story(?:\\#\\{\\d+\\})?(?:\\,)?)",
+            "match": "(\\s*\\/?[^\\s]*\\.story(?:\\#\\{[\\w:]+\\})?(?:\\,)?)",
             "name": "vividus.keyword.attribute"
         },
         "examples": {

--- a/syntaxes/vividus.story.tmLanguage.json
+++ b/syntaxes/vividus.story.tmLanguage.json
@@ -22,6 +22,9 @@
         },
         {
             "include": "#examples"
+        },
+        {
+            "include": "#description"
         }
     ],
     "scopeName": "source.vividus",
@@ -198,6 +201,18 @@
                     "name": "vividus.keyword.attribute"
                 }
             }
+        },
+        "description": {
+            "begin": "^(Description:)(.*)$",
+            "beginCaptures": {
+                "1": {
+                    "name": "vividus.keyword"
+                },
+                "2": {
+                    "name": "vividus.comment"
+                }
+            },
+            "end": "$"
         }
     }
 }


### PR DESCRIPTION
Proposed changes:

1.  Fix GivenStoriesPath pattern.
_At present, Visual Studio Code highlights "GivenStories" that contain only numerical digits within the curly brackets. However, it should be noted that sometimes, stories have more complex metadata that needs to be included within the pathway._
![ScreenShot 2024-02-14-14 02 48](https://github.com/vividus-framework/vividus-studio/assets/66934999/c7f7f88d-a6a0-4389-b7b3-7800517888f8)
![ScreenShot 2024-02-14-13 59 27](https://github.com/vividus-framework/vividus-studio/assets/66934999/92fa99cc-1546-4466-a094-37546747a4d8)
_To be:_
![ScreenShot 2024-02-14-14 07 39](https://github.com/vividus-framework/vividus-studio/assets/66934999/96a24e22-fd8b-46b5-af46-daa6fa3c23a5)
2. Add **Description** pattern.
_Some of the stories may include description, that currently is not highlighted_
![ScreenShot 2024-02-14-14 04 17](https://github.com/vividus-framework/vividus-studio/assets/66934999/f41735c8-b33e-4541-9b77-d0f9d927dd2a)
_To be:_
![ScreenShot 2024-02-14-14 06 59](https://github.com/vividus-framework/vividus-studio/assets/66934999/2834f95b-8dba-45b8-977a-ffa8651e9f54)
