### PR TITLE
Rename JDK to Java in messages shown to user

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
                 "vscode-test": "^1.6.1"
             },
             "engines": {
-                "vscode": "^1.92.0"
+                "vscode": "^1.93.0"
             }
         },
         "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
                             "null"
                         ],
                         "default": null,
-                        "description": "The directory path containing JDK to run the extension"
+                        "description": "The directory path containing Java to run the extension"
                     },
                     "vividus-studio.stories-runner": {
                         "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,7 +59,7 @@ export function activate(context: ExtensionContext) {
 async function createServerOptions(context: ExtensionContext): Promise<StreamInfo> {
 
     const javaRuntime: IJavaRuntime = await findJavaExecutable();
-    window.showInformationMessage(`Using JDK ${javaRuntime.version?.java_version}`);
+    window.showInformationMessage(`Using Java ${javaRuntime.version?.java_version}`);
 
     return new Promise(async (res, rej) => {
         const server = createServer(connection => res({ writer: connection, reader: connection }));

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,12 +9,12 @@ export async function findJavaExecutable(): Promise<IJavaRuntime> {
         const runtime: IJavaRuntime = await getRuntime(userJavaHome, { withVersion: true }) as IJavaRuntime;
 
         if (!runtime) {
-            throw new Error(`Unable to find JDK at location specified by ${javaHomeProperty} user property: ${userJavaHome}`);
+            throw new Error(`Unable to find Java at location specified by ${javaHomeProperty} user property: ${userJavaHome}`);
         }
 
         if (runtime.version?.major as number < 17) {
-            throw new Error(`The ${javaHomeProperty} user property points to JDK ${runtime.version?.java_version} installation,`
-                + ` but JDK 17 or higher is required`)
+            throw new Error(`The ${javaHomeProperty} user property points to Java ${runtime.version?.java_version} installation,`
+                + ` but Java 17 or higher is required`)
         }
 
         return runtime;
@@ -26,7 +26,7 @@ export async function findJavaExecutable(): Promise<IJavaRuntime> {
     }) as IJavaRuntime;
 
     if (!runtime) {
-        throw new Error('Unable to find JDK 17 or higher installation');
+        throw new Error('Unable to find Java 17 or higher installation');
     }
 
     return runtime;

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -12,7 +12,7 @@ suite('Utils', () => {
         sinon.restore()
     })
 
-    const jdk13: IJavaRuntime = {
+    const java13: IJavaRuntime = {
         homedir: 'home_dir',
         version: {
             java_version: '13.0.2',
@@ -20,7 +20,7 @@ suite('Utils', () => {
         }
     }
 
-    const jdk17: IJavaRuntime = {
+    const java17: IJavaRuntime = {
         homedir: 'home_dir',
         version: {
             java_version: '17.0.2',
@@ -30,29 +30,29 @@ suite('Utils', () => {
 
     const jdkUtilsModule = require('jdk-utils')
 
-    test('Should return JDK 17 installation pointed by vividus-studio.java-home property', async () => {
-        const getRuntimeStub: SinonStub = sinon.stub(jdkUtilsModule, 'getRuntime').returns(jdk17)
+    test('Should return Java 17 installation pointed by vividus-studio.java-home property', async () => {
+        const getRuntimeStub: SinonStub = sinon.stub(jdkUtilsModule, 'getRuntime').returns(java17)
 
         sinon.stub(workspace, 'getConfiguration').returns(<WorkspaceConfiguration>{
             get: (section: string) => { return 'home_dir' }
         });
 
-        assert.equal(jdk17, await findJavaExecutable())
+        assert.equal(java17, await findJavaExecutable())
         assert.equal(true, getRuntimeStub.calledWith('home_dir', { withVersion: true }))
     })
 
-    test('Should return JDK 17 system installation', async () => {
-        const getRuntimeStub: SinonStub = sinon.stub(jdkUtilsModule, 'findRuntimes').returns([jdk17])
+    test('Should return Java 17 system installation', async () => {
+        const getRuntimeStub: SinonStub = sinon.stub(jdkUtilsModule, 'findRuntimes').returns([java17])
 
         sinon.stub(workspace, 'getConfiguration').returns(<WorkspaceConfiguration>{
             get: (section: string) => { return null }
         });
 
-        assert.equal(jdk17, await findJavaExecutable())
+        assert.equal(java17, await findJavaExecutable())
         assert.equal(true, getRuntimeStub.calledWith({ withVersion: true }))
     })
 
-    test('Should fail if vividus-studio.java-home property points to not java dir', async () => {
+    test('Should fail if vividus-studio.java-home property points to not Java dir', async () => {
         const getRuntimeStub: SinonStub = sinon.stub(jdkUtilsModule, 'getRuntime').returns(undefined)
 
         sinon.stub(workspace, 'getConfiguration').returns(<WorkspaceConfiguration>{
@@ -60,33 +60,33 @@ suite('Utils', () => {
         });
 
         await assert.rejects(findJavaExecutable(),
-            { message: 'Unable to find JDK at location specified by vividus-studio.java-home user property: home_dir' })
+            { message: 'Unable to find Java at location specified by vividus-studio.java-home user property: home_dir' })
         assert.equal(true, getRuntimeStub.calledOnce)
         assert.equal(true, getRuntimeStub.calledWith('home_dir', { withVersion: true }))
     })
 
-    test('Should fail if vividus-studio.java-home property points to old jdk versions', async () => {
-        const getRuntimeStub: SinonStub = sinon.stub(jdkUtilsModule, 'getRuntime').returns(jdk13)
+    test('Should fail if vividus-studio.java-home property points to old Java versions', async () => {
+        const getRuntimeStub: SinonStub = sinon.stub(jdkUtilsModule, 'getRuntime').returns(java13)
 
         sinon.stub(workspace, 'getConfiguration').returns(<WorkspaceConfiguration>{
             get: (section: string) => { return 'home_dir' }
         });
 
         await assert.rejects(findJavaExecutable(),
-            { message: 'The vividus-studio.java-home user property points to JDK 13.0.2 installation, but JDK 17 or higher is required' })
+            { message: 'The vividus-studio.java-home user property points to Java 13.0.2 installation, but Java 17 or higher is required' })
         assert.equal(true, getRuntimeStub.calledOnce)
         assert.equal(true, getRuntimeStub.calledWith('home_dir', { withVersion: true }))
     })
 
-    test('Should fail if there is no JDK 17 installed in the system', async () => {
-        const getRuntimeStub: SinonStub = sinon.stub(jdkUtilsModule, 'findRuntimes').returns([jdk13])
+    test('Should fail if there is no Java 17 installed in the system', async () => {
+        const getRuntimeStub: SinonStub = sinon.stub(jdkUtilsModule, 'findRuntimes').returns([java13])
 
         sinon.stub(workspace, 'getConfiguration').returns(<WorkspaceConfiguration>{
             get: (section: string) => { return null }
         });
 
         await assert.rejects(findJavaExecutable(),
-            { message: 'Unable to find JDK 17 or higher installation' })
+            { message: 'Unable to find Java 17 or higher installation' })
         assert.equal(true, getRuntimeStub.calledOnce)
         assert.equal(true, getRuntimeStub.calledWith({ withVersion: true }))
     })


### PR DESCRIPTION
JDK is not required, JRE is enough. JDK is renamed to Java in messages show to users to make them less restrictive.