### PR TITLE
Bump VS Code engine from 1.102.0 to 1.104.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 * Add `VIVIDUS Studio Debug` channel for improved client side logging
+* Bump VS Code engine from 1.102.0 to 1.104.0
 
 ## [0.2.10] - 2025-12-09
 * Fix invalid syntax naming for failure outcome

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "@types/mocha": "^10.0.10",
                 "@types/node": "^25.3.0",
                 "@types/sinon": "^21.0.0",
-                "@types/vscode": "^1.102.0",
+                "@types/vscode": "^1.104.0",
                 "@vscode/test-electron": "^2.3.8",
                 "eslint": "^9.39.1",
                 "mocha": "^11.7.5",
@@ -27,7 +27,7 @@
                 "typescript-eslint": "^8.56.0"
             },
             "engines": {
-                "vscode": "^1.102.0"
+                "vscode": "^1.104.0"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -434,10 +434,11 @@
             "dev": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.103.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.103.0.tgz",
-            "integrity": "sha512-o4hanZAQdNfsKecexq9L3eHICd0AAvdbLk6hA60UzGXbGH/q8b/9xv2RgR7vV3ZcHuyKVq7b37IGd/+gM4Tu+Q==",
-            "dev": true
+            "version": "1.109.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.109.0.tgz",
+            "integrity": "sha512-0Pf95rnwEIwDbmXGC08r0B4TQhAbsHQ5UyTIgVgoieDe4cOnf92usuR5dEczb6bTKEp7ziZH4TV1TRGPPCExtw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.56.0",
@@ -481,6 +482,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.0.tgz",
             "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.56.0",
                 "@typescript-eslint/types": "8.56.0",
@@ -755,6 +757,7 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1010,6 +1013,7 @@
             "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -2667,6 +2671,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
             "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -3263,9 +3268,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.103.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.103.0.tgz",
-            "integrity": "sha512-o4hanZAQdNfsKecexq9L3eHICd0AAvdbLk6hA60UzGXbGH/q8b/9xv2RgR7vV3ZcHuyKVq7b37IGd/+gM4Tu+Q==",
+            "version": "1.109.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.109.0.tgz",
+            "integrity": "sha512-0Pf95rnwEIwDbmXGC08r0B4TQhAbsHQ5UyTIgVgoieDe4cOnf92usuR5dEczb6bTKEp7ziZH4TV1TRGPPCExtw==",
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
@@ -3297,6 +3302,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.0.tgz",
             "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@typescript-eslint/scope-manager": "8.56.0",
                 "@typescript-eslint/types": "8.56.0",
@@ -3464,7 +3470,8 @@
             "version": "8.15.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "acorn-jsx": {
             "version": "5.3.2",
@@ -3638,6 +3645,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
             "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -4761,7 +4769,8 @@
             "version": "5.5.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
             "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "typescript-eslint": {
             "version": "8.56.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "license": "Apache-2.0",
     "engines": {
-        "vscode": "^1.102.0"
+        "vscode": "^1.104.0"
     },
     "categories": [
         "Debuggers",
@@ -265,7 +265,7 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^25.3.0",
         "@types/sinon": "^21.0.0",
-        "@types/vscode": "^1.102.0",
+        "@types/vscode": "^1.104.0",
         "@vscode/test-electron": "^2.3.8",
         "eslint": "^9.39.1",
         "mocha": "^11.7.5",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum VS Code engine version requirement to 1.104.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->